### PR TITLE
Don't include generated_definitions.hpp.

### DIFF
--- a/src/g3log/crashhandler.hpp
+++ b/src/g3log/crashhandler.hpp
@@ -11,7 +11,6 @@
 #include <csignal>
 #include <map>
 #include "g3log/loglevels.hpp"
-#include "g3log/generated_definitions.hpp"
 
 // kjell. Separera på crashhandler.hpp och crashhanlder_internal.hpp
 // implementationsfilen kan vara den samma

--- a/src/g3log/loglevels.hpp
+++ b/src/g3log/loglevels.hpp
@@ -7,7 +7,6 @@
 * ============================================================================*/
 
 #pragma once
-#include "g3log/generated_definitions.hpp"
 #include "g3log/g3dll.hpp"
 // Users of Juce or other libraries might have a define DEBUG which clashes with
 // the DEBUG logging level for G3log. In that case they can instead use the define


### PR DESCRIPTION
We build g3log ourselves, so dependents will see the same defines and
don't need this functionality.
